### PR TITLE
feat(fixtures): add compliant and violating projects for CPRIMA-USG-001 ShouldStop presence rule

### DIFF
--- a/CPRIMA-USG-001_ShouldStopPresence/NoViolation/.gitattributes
+++ b/CPRIMA-USG-001_ShouldStopPresence/NoViolation/.gitattributes
@@ -1,0 +1,19 @@
+# Treat all XAML as binary but detectable
+*.xaml binary linguist-detectable
+
+# JSON files (structured text, keep normalized)
+*.json text eol=lf
+
+# Markdown (docs)
+*.md text eol=lf
+
+# UiPath settings or log files — optional
+*.settings.json text eol=lf
+*.log text eol=lf
+
+# Prevent diff noise from BOMs or line endings
+*.txt text eol=lf
+*.xml text eol=lf
+
+# Ignore project lock files in stats
+project.assets.json linguist-generated

--- a/CPRIMA-USG-001_ShouldStopPresence/NoViolation/.gitignore
+++ b/CPRIMA-USG-001_ShouldStopPresence/NoViolation/.gitignore
@@ -1,0 +1,14 @@
+#In older versions of studio, local entity dlls are stored in a different directory, hence the below code
+#Ignore .local files without ignoring dataservice object .dlls
+.local/
+!.local/**/*.dlls
+
+#Ignore Debug And Design-Time Settings, Don't Ignore Release Settings
+.settings/Debug/
+.settings/Design/
+
+#Ignore Generated Hashes, Reduce Diff Size
+.objects/**/.attributes/SearchHash
+.objects/**/.hash
+
+RnD/

--- a/CPRIMA-USG-001_ShouldStopPresence/NoViolation/Main.xaml
+++ b/CPRIMA-USG-001_ShouldStopPresence/NoViolation/Main.xaml
@@ -1,0 +1,69 @@
+<Activity mc:Ignorable="sap sap2010" x:Class="Main" VisualBasic.Settings="{x:Null}" sap2010:WorkflowViewState.IdRef="Main_1" xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation" xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=System.Private.CoreLib" xmlns:sco="clr-namespace:System.Collections.ObjectModel;assembly=System.Private.CoreLib" xmlns:ui="http://schemas.uipath.com/workflow/activities" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <TextExpression.NamespacesForImplementation>
+    <sco:Collection x:TypeArguments="x:String">
+      <x:String>System.Activities</x:String>
+      <x:String>System.Activities.Statements</x:String>
+      <x:String>System.Activities.Expressions</x:String>
+      <x:String>System.Activities.Validation</x:String>
+      <x:String>System.Activities.XamlIntegration</x:String>
+      <x:String>Microsoft.VisualBasic</x:String>
+      <x:String>Microsoft.VisualBasic.Activities</x:String>
+      <x:String>System</x:String>
+      <x:String>System.Collections</x:String>
+      <x:String>System.Collections.Generic</x:String>
+      <x:String>System.Collections.ObjectModel</x:String>
+      <x:String>System.Data</x:String>
+      <x:String>System.Diagnostics</x:String>
+      <x:String>System.Drawing</x:String>
+      <x:String>System.IO</x:String>
+      <x:String>System.Linq</x:String>
+      <x:String>System.Net.Mail</x:String>
+      <x:String>System.Xml</x:String>
+      <x:String>System.Xml.Linq</x:String>
+      <x:String>UiPath.Core</x:String>
+      <x:String>UiPath.Core.Activities</x:String>
+      <x:String>System.Windows.Markup</x:String>
+      <x:String>GlobalVariablesNamespace</x:String>
+      <x:String>GlobalConstantsNamespace</x:String>
+      <x:String>System.Reflection</x:String>
+    </sco:Collection>
+  </TextExpression.NamespacesForImplementation>
+  <TextExpression.ReferencesForImplementation>
+    <sco:Collection x:TypeArguments="AssemblyReference">
+      <AssemblyReference>Microsoft.VisualBasic</AssemblyReference>
+      <AssemblyReference>mscorlib</AssemblyReference>
+      <AssemblyReference>System</AssemblyReference>
+      <AssemblyReference>System.Activities</AssemblyReference>
+      <AssemblyReference>System.ComponentModel.TypeConverter</AssemblyReference>
+      <AssemblyReference>System.Core</AssemblyReference>
+      <AssemblyReference>System.Data</AssemblyReference>
+      <AssemblyReference>System.Data.Common</AssemblyReference>
+      <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
+      <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
+      <AssemblyReference>System.Linq</AssemblyReference>
+      <AssemblyReference>System.Net.Mail</AssemblyReference>
+      <AssemblyReference>System.ObjectModel</AssemblyReference>
+      <AssemblyReference>System.Private.CoreLib</AssemblyReference>
+      <AssemblyReference>System.Xaml</AssemblyReference>
+      <AssemblyReference>System.Xml</AssemblyReference>
+      <AssemblyReference>System.Xml.Linq</AssemblyReference>
+      <AssemblyReference>UiPath.System.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.UiAutomation.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.Studio.Constants</AssemblyReference>
+      <AssemblyReference>System.Reflection.DispatchProxy</AssemblyReference>
+      <AssemblyReference>System.Reflection.TypeExtensions</AssemblyReference>
+      <AssemblyReference>System.Reflection.Metadata</AssemblyReference>
+      <AssemblyReference>System.Reflection.MetadataLoadContext</AssemblyReference>
+    </sco:Collection>
+  </TextExpression.ReferencesForImplementation>
+  <Sequence DisplayName="Main" sap:VirtualizedContainerService.HintSize="596,362.04" sap2010:WorkflowViewState.IdRef="Sequence_1">
+    <sap:WorkflowViewStateService.ViewState>
+      <scg:Dictionary x:TypeArguments="x:String, x:Object">
+        <x:Boolean x:Key="IsExpanded">True</x:Boolean>
+      </scg:Dictionary>
+    </sap:WorkflowViewStateService.ViewState>
+    <ui:ShouldStop DisplayName="Should Stop CPRIMA-USG-001 compliance" sap:VirtualizedContainerService.HintSize="416,48" sap2010:WorkflowViewState.IdRef="ShouldStop_1" />
+  </Sequence>
+</Activity>

--- a/CPRIMA-USG-001_ShouldStopPresence/NoViolation/project.json
+++ b/CPRIMA-USG-001_ShouldStopPresence/NoViolation/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "CPRIMA-USG-001-Compliant",
+  "description": "Demonstrates a UiPath project that includes a ShouldStop activity as required by rule CPRIMA-USG-001. This project complies with the custom Workflow Analyzer rule.",
+  "dependencies": {
+    "UiPath.System.Activities": "[22.10.4]",
+    "UiPath.Testing.Activities": "[22.10.3]"
+  },
+  "main": "Main.xaml",
+  "projectType": "Process",
+  "schemaVersion": "4.0",
+  "studioVersion": "22.10.5.0",
+  "targetFramework": "Windows"
+}

--- a/CPRIMA-USG-001_ShouldStopPresence/Violation/.gitattributes
+++ b/CPRIMA-USG-001_ShouldStopPresence/Violation/.gitattributes
@@ -1,0 +1,19 @@
+# Treat all XAML as binary but detectable
+*.xaml binary linguist-detectable
+
+# JSON files (structured text, keep normalized)
+*.json text eol=lf
+
+# Markdown (docs)
+*.md text eol=lf
+
+# UiPath settings or log files — optional
+*.settings.json text eol=lf
+*.log text eol=lf
+
+# Prevent diff noise from BOMs or line endings
+*.txt text eol=lf
+*.xml text eol=lf
+
+# Ignore project lock files in stats
+project.assets.json linguist-generated

--- a/CPRIMA-USG-001_ShouldStopPresence/Violation/.gitignore
+++ b/CPRIMA-USG-001_ShouldStopPresence/Violation/.gitignore
@@ -1,0 +1,14 @@
+#In older versions of studio, local entity dlls are stored in a different directory, hence the below code
+#Ignore .local files without ignoring dataservice object .dlls
+.local/
+!.local/**/*.dlls
+
+#Ignore Debug And Design-Time Settings, Don't Ignore Release Settings
+.settings/Debug/
+.settings/Design/
+
+#Ignore Generated Hashes, Reduce Diff Size
+.objects/**/.attributes/SearchHash
+.objects/**/.hash
+
+RnD/

--- a/CPRIMA-USG-001_ShouldStopPresence/Violation/Main.xaml
+++ b/CPRIMA-USG-001_ShouldStopPresence/Violation/Main.xaml
@@ -1,0 +1,62 @@
+<Activity mc:Ignorable="sap sap2010" x:Class="Main" VisualBasic.Settings="{x:Null}" sap2010:WorkflowViewState.IdRef="Main_1" xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation" xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=System.Private.CoreLib" xmlns:sco="clr-namespace:System.Collections.ObjectModel;assembly=System.Private.CoreLib" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <TextExpression.NamespacesForImplementation>
+    <sco:Collection x:TypeArguments="x:String">
+      <x:String>System.Activities</x:String>
+      <x:String>System.Activities.Statements</x:String>
+      <x:String>System.Activities.Expressions</x:String>
+      <x:String>System.Activities.Validation</x:String>
+      <x:String>System.Activities.XamlIntegration</x:String>
+      <x:String>Microsoft.VisualBasic</x:String>
+      <x:String>Microsoft.VisualBasic.Activities</x:String>
+      <x:String>System</x:String>
+      <x:String>System.Collections</x:String>
+      <x:String>System.Collections.Generic</x:String>
+      <x:String>System.Collections.ObjectModel</x:String>
+      <x:String>System.Data</x:String>
+      <x:String>System.Diagnostics</x:String>
+      <x:String>System.Drawing</x:String>
+      <x:String>System.IO</x:String>
+      <x:String>System.Linq</x:String>
+      <x:String>System.Net.Mail</x:String>
+      <x:String>System.Xml</x:String>
+      <x:String>System.Xml.Linq</x:String>
+      <x:String>UiPath.Core</x:String>
+      <x:String>UiPath.Core.Activities</x:String>
+      <x:String>System.Windows.Markup</x:String>
+      <x:String>GlobalVariablesNamespace</x:String>
+      <x:String>GlobalConstantsNamespace</x:String>
+    </sco:Collection>
+  </TextExpression.NamespacesForImplementation>
+  <TextExpression.ReferencesForImplementation>
+    <sco:Collection x:TypeArguments="AssemblyReference">
+      <AssemblyReference>Microsoft.VisualBasic</AssemblyReference>
+      <AssemblyReference>mscorlib</AssemblyReference>
+      <AssemblyReference>System</AssemblyReference>
+      <AssemblyReference>System.Activities</AssemblyReference>
+      <AssemblyReference>System.ComponentModel.TypeConverter</AssemblyReference>
+      <AssemblyReference>System.Core</AssemblyReference>
+      <AssemblyReference>System.Data</AssemblyReference>
+      <AssemblyReference>System.Data.Common</AssemblyReference>
+      <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
+      <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Drawing.Common</AssemblyReference>
+      <AssemblyReference>System.Drawing.Primitives</AssemblyReference>
+      <AssemblyReference>System.Linq</AssemblyReference>
+      <AssemblyReference>System.Net.Mail</AssemblyReference>
+      <AssemblyReference>System.ObjectModel</AssemblyReference>
+      <AssemblyReference>System.Private.CoreLib</AssemblyReference>
+      <AssemblyReference>System.Xaml</AssemblyReference>
+      <AssemblyReference>System.Xml</AssemblyReference>
+      <AssemblyReference>System.Xml.Linq</AssemblyReference>
+      <AssemblyReference>UiPath.System.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.UiAutomation.Activities</AssemblyReference>
+    </sco:Collection>
+  </TextExpression.ReferencesForImplementation>
+  <Sequence DisplayName="Main" sap:VirtualizedContainerService.HintSize="596,247.1828571428571" sap2010:WorkflowViewState.IdRef="Sequence_1">
+    <sap:WorkflowViewStateService.ViewState>
+      <scg:Dictionary x:TypeArguments="x:String, x:Object">
+        <x:Boolean x:Key="IsExpanded">True</x:Boolean>
+      </scg:Dictionary>
+    </sap:WorkflowViewStateService.ViewState>
+  </Sequence>
+</Activity>

--- a/CPRIMA-USG-001_ShouldStopPresence/Violation/project.json
+++ b/CPRIMA-USG-001_ShouldStopPresence/Violation/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "CPRIMA-USG-001-Violating",
+  "description": "Demonstrates a UiPath project that omits the ShouldStop activity, thereby violating rule CPRIMA-USG-001. This project is intended to trigger the rule’s error condition.",
+  "dependencies": {
+    "UiPath.System.Activities": "[22.10.4]",
+    "UiPath.Testing.Activities": "[22.10.3]"
+  },
+  "main": "Main.xaml",
+  "projectType": "Process",
+  "schemaVersion": "4.0",
+  "studioVersion": "22.10.5.0",
+  "targetFramework": "Windows"
+}


### PR DESCRIPTION
# 📦 Pull Request Summary

This pull request promotes the initial fixture projects for `CPRIMA-USG-001 - ShouldStop Activity Presence Check` from `develop` into `main`.

It includes:

* A **violating** UiPath project (missing `ShouldStop`)
* A **compliant** UiPath project (contains `ShouldStop`)
* Aligned metadata, folder structure, and `.gitattributes` handling

These projects serve as minimal reference fixtures for custom rule development.

Fixes: #1 
Depends on: *n/a*

## ✅ Checklist

* [x] I have tested this change locally
* [x] I have documented any new functionality
* [x] I have linked related issues and PRs
* [x] This PR follows the repo’s contribution guidelines


## 📜 Commits in This PR

```bash
git log --oneline --graph --decorate origin/main..HEAD
```

Expected to show:

```
* feat(fixtures): add compliant and violating projects for CPRIMA-USG-001 ShouldStop presence rule
```


## 💬 Additional Notes

* `.xaml` files are marked as `binary linguist-detectable`
* `project.json` uses pinned dependencies
* Folder named `CPRIMA-USG-001_ShouldStopPresence` per repo standard
